### PR TITLE
feat: add findLast and findLastIndex examples

### DIFF
--- a/script.js
+++ b/script.js
@@ -525,3 +525,12 @@ for (const acc of accounts) {
   if (acc.owner === 'Jessica Davis') console.log(acc);
 }
 */
+
+console.log(movements);
+
+const lastWithdrawal = movements.findLast((mov) => mov < 0);
+console.log(lastWithdrawal);
+
+const latestLargeMovementIndex = movements.findLastIndex((mov) => Math.abs(mov) > 2000);
+console.log(latestLargeMovementIndex);
+console.log(`your latest large movements was ${movements.length - latestLargeMovementIndex} movements ago `);


### PR DESCRIPTION
### Log full `movements` array for reference
- Use `findLast` to retrieve the most recent withdrawal
- Use `findLastIndex` to locate the last “large” movement (>2000)
- Calculate and log “X movements ago” using array length and found index