### PR TITLE
Add practice for flat and flatMap methods

### DIFF
--- a/script.js
+++ b/script.js
@@ -554,6 +554,9 @@ console.log(latestLargeMovementIndex);
 console.log(`your latest large movements was ${movements.length - latestLargeMovementIndex} movements ago `);
 */
 
+/*
+// 169-some-and-every
+
 // EQUALITY
 console.log(movements);
 console.log(movements.includes(-130));
@@ -575,3 +578,21 @@ const deposit = (mov) => mov > 0;
 console.log(movements.some(deposit));
 console.log(movements.every(deposit));
 console.log(movements.filter(deposit));
+*/
+
+const arr = [[1, 2, 3], [4, 5, 6], 7, 8];
+console.log(arr.flat());
+
+const arrDeep = [[[1, 2], 3], [4, [5, 6]], 7, 8];
+console.log(arrDeep.flat(2));
+
+// flat
+const overalBalance = accounts
+  .map((mov) => mov.movements)
+  .flat()
+  .reduce((acc, mov) => acc + mov, 0);
+console.log(overalBalance);
+
+// flatMap
+const overalBalance2 = accounts.flatMap((mov) => mov.movements).reduce((acc, mov) => acc + mov, 0);
+console.log(overalBalance2);


### PR DESCRIPTION
- Demonstrate `Array.prototype.flat()` on simple and deeply nested arrays  
- Use `flat(depth)` to flatten arrays multiple levels deep  
- Compute overall balance by chaining `map` → `flat` → `reduce` on `accounts` data  
- Show `flatMap` as an optimized combination of `map` and `flat` for one-level flattening  
